### PR TITLE
cd dependencies && mvn initialize

### DIFF
--- a/ispyb-ejb/pom.xml
+++ b/ispyb-ejb/pom.xml
@@ -174,7 +174,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.