### PR TITLE
mvn -Dispyb.site=ESRF -Dispyb.env=test clean install

### DIFF
--- a/ispyb-bcr/pom.xml
+++ b/ispyb-bcr/pom.xml
@@ -181,7 +181,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.4</version>
+			<version>2.7</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-lang</groupId>


### PR DESCRIPTION
Bumps commons-io from 2.4 to 2.7.